### PR TITLE
auto‑detect network interface; remove hardcoded wlp4s0

### DIFF
--- a/dotfiles/eww/scripts/net/net_download.sh
+++ b/dotfiles/eww/scripts/net/net_download.sh
@@ -9,14 +9,16 @@
 #
 # ─────────────────────────────────────────────────────────────────────────────
 
-iface="wlp4s0"   # Wi-Fi interface
-max_speed=12500000   # adjust: this is 100 Mbps (100*1e6 / 8)
+iface="${NET_IFACE:-$(ip -4 -o route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="dev"){print $(i+1); exit}}')}"
+[[ -z "${iface:-}" ]] && iface="${NET_IFACE:-$(ip -4 -o route 2>/dev/null | awk '/default/ {print $5; exit}')}"
+[[ -z "${iface:-}" ]] && { echo 0; exit 0; }
+max_speed="${MAX_SPEED_BYTES:-12500000}"   # 100 Mbps default; override via env
 
 # First sample
-rx1=$(awk -v iface=$iface '$1 ~ iface {gsub(":", "", $1); print $2}' /proc/net/dev)
+rx1=$(awk -F'[: ]+' -v iface="$iface" '$2==iface {print $3}' /proc/net/dev)
 sleep 1
 # Second sample
-rx2=$(awk -v iface=$iface '$1 ~ iface {gsub(":", "", $1); print $2}' /proc/net/dev)
+rx2=$(awk -F'[: ]+' -v iface="$iface" '$2==iface {print $3}' /proc/net/dev)
 
 bps=$((rx2 - rx1))              # bytes per second
 percent=$((bps * 100 / max_speed))

--- a/dotfiles/eww/scripts/net/net_upload.sh
+++ b/dotfiles/eww/scripts/net/net_upload.sh
@@ -5,17 +5,19 @@
 #  as a percentage (0–100) of a configured max speed.
 # ─────────────────────────────────────────────────────────────────────────────
 
-iface="wlp4s0"        # your active Wi-Fi interface (from `ip -br link`)
-max_speed=12500000    # 100 Mbps = 100e6 / 8 (bytes/sec). Adjust if faster.
+iface="${NET_IFACE:-$(ip -4 -o route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="dev"){print $(i+1); exit}}')}"        # auto-detect; override via NET_IFACE
+[[ -z "${iface:-}" ]] && iface="${NET_IFACE:-$(ip -4 -o route 2>/dev/null | awk '/default/ {print $5; exit}')}"
+[[ -z "${iface:-}" ]] && { echo 0; exit 0; }
+max_speed="${MAX_SPEED_BYTES:-12500000}"    # 100 Mbps default; override via env
 
 # First sample
-tx1=$(awk -v iface=$iface '$1 ~ iface {gsub(":", "", $1); print $10}' /proc/net/dev)
+tx1=$(awk -F'[: ]+' -v iface="$iface" '$2==iface {print $11}' /proc/net/dev)
 sleep 1
 # Second sample
-tx2=$(awk -v iface=$iface '$1 ~ iface {gsub(":", "", $1); print $10}' /proc/net/dev)
+tx2=$(awk -F'[: ]+' -v iface="$iface" '$2==iface {print $11}' /proc/net/dev)
 
 bps=$((tx2 - tx1))                 # bytes per second
-percent=$((bps * 1000 / max_speed))  # scaled ×10 for sensitivity
+percent=$((bps * 100 / max_speed))
 
 # Clamp between 0–100
 if [ "$percent" -gt 100 ]; then percent=100; fi

--- a/dotfiles/eww/scripts/net/net_vpn_bar.sh
+++ b/dotfiles/eww/scripts/net/net_vpn_bar.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # ~/.config/eww/scripts/net/net_vpn_bar.sh
-# Render a 5-line bar directly based on VPN (ipsec) status.
+# Render a 5-line bar directly based on VPN local detection (no external calls).
 
 lines=5
-
-if sudo /usr/bin/ipsec statusall 2>/dev/null | grep -q "ESTABLISHED"; then
+VPN_NETS_REGEX="${VPN_NETS_REGEX:-^10\\.6\\.}"
+if ip -4 -o addr show 2>/dev/null | awk -v re="$VPN_NETS_REGEX" '$3=="inet" && $4 ~ re {found=1} END{exit !found}' \
+   || (command -v ipsec >/dev/null 2>&1 && ipsec statusall 2>/dev/null | grep -q "ESTABLISHED"); then
   # VPN is up → full block bar
   for ((i=0; i<lines; i++)); do
     echo "█"

--- a/dotfiles/eww/scripts/net/net_vpn_status.sh
+++ b/dotfiles/eww/scripts/net/net_vpn_status.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # ~/.config/eww/scripts/net/net_vpn_status.sh
-# Show VPN status + country (for Eww)
+# Show VPN status (local check, no external calls)
 
-if sudo /usr/bin/ipsec statusall 2>/dev/null | grep -q "ESTABLISHED"; then
-  country=$(curl -s ifconfig.co/country 2>/dev/null)
-  [[ -z "$country" ]] && country="UNKNOWN"
-  echo "[ФАНТОМ]"
+VPN_NETS_REGEX="${VPN_NETS_REGEX:-^10\\.6\\.}"
+if ip -4 -o addr show 2>/dev/null | awk -v re="$VPN_NETS_REGEX" '$3=="inet" && $4 ~ re {found=1} END{exit !found}' \
+   || (command -v ipsec >/dev/null 2>&1 && ipsec statusall 2>/dev/null | grep -q "ESTABLISHED"); then
+  echo "[VPN]"
 else
-  echo "KAPUTT"
+  echo ""
 fi
 

--- a/dotfiles/hypr/hyprland.conf
+++ b/dotfiles/hypr/hyprland.conf
@@ -173,7 +173,7 @@ bind = , XF86KbdBrightnessDown, exec, bash ~/.config/kbd-brightness.sh down
 bind = , XF86KbdBrightnessUp,   exec, bash ~/.config/kbd-brightness.sh up
 bind = , XF86Launch3,           exec, bash ~/.config/kbd-breathing.sh
 exec-once = bash ~/.config/kbd-brightness.sh &
-bind = , XF86Launch4, exec, ~/.config/hypr/scripts/asus-kbd/cycle-profile.sh
+bind = , XF86Launch4, exec, $HOME/.config/hypr/scripts/asus-kbd/cycle-profile.sh
 
 # Touchpad / Monitor
 bind = , XF86Display,       exec, hyprctl dispatch cyclenextmonitor

--- a/dotfiles/hypr/hyprland.conf
+++ b/dotfiles/hypr/hyprland.conf
@@ -173,7 +173,7 @@ bind = , XF86KbdBrightnessDown, exec, bash ~/.config/kbd-brightness.sh down
 bind = , XF86KbdBrightnessUp,   exec, bash ~/.config/kbd-brightness.sh up
 bind = , XF86Launch3,           exec, bash ~/.config/kbd-breathing.sh
 exec-once = bash ~/.config/kbd-brightness.sh &
-bind = , XF86Launch4, exec, ~/.config/hypr/scripts/asus-kbd/cycle-profile.s
+bind = , XF86Launch4, exec, ~/.config/hypr/scripts/asus-kbd/cycle-profile.sh
 
 # Touchpad / Monitor
 bind = , XF86Display,       exec, hyprctl dispatch cyclenextmonitor

--- a/dotfiles/hypr/scripts/waybar_watcher.sh
+++ b/dotfiles/hypr/scripts/waybar_watcher.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-logfile="/tmp/waybar_watcher_loop_final.log"
+logfile="${HYPR_WATCHER_LOGFILE:-/dev/null}"
 
 # Wallpapers
 wallpaper_with_window="/home/pewds/.config/hypr/wallpapers/black.png"

--- a/dotfiles/waybar/config
+++ b/dotfiles/waybar/config
@@ -85,7 +85,7 @@
     "format": "{}",
     "tooltip": true,
     "tooltip-format": "Toggle ASUS profile",
-    "on-click": "/home/pewds/.config/cycle-profile.sh"
+    "on-click": "$HOME/.config/hypr/scripts/asus-kbd/cycle-profile.sh"
   },
 
 

--- a/dotfiles/waybar/scripts/nordvpn-status.sh
+++ b/dotfiles/waybar/scripts/nordvpn-status.sh
@@ -1,20 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ── nordvpn-status.sh ──────────────────────────────────────
 # Description: Checks if VPN interface is active via IP range
 # Usage: Called by Waybar `custom/vpn` every 5s
-# Dependencies: ip, curl (optional, for country lookup)
-# Output: Pango markup → [ФАНТОМ]: Country or KAPUTT
+# Dependencies: ip (no external calls in steady state)
+# Output: Pango markup → [VPN] or empty
 # Example: <span foreground='#fab387'>[ФАНТОМ]: Japan</span>
 #          <span foreground='#bf616a'>[ФАНТОМ]: KAPUTT</span>
 # ───────────────────────────────────────────────────────────
 
-#!/bin/bash
-
-if sudo ipsec statusall 2>/dev/null | grep -q "ESTABLISHED"; then
-  country=$(curl -s ifconfig.co/country 2>/dev/null)
-  [[ -z "$country" ]] && country="UNKNOWN"
-  echo "<span foreground='#fab387'>[ФАНТОМ]: $country</span>"
+VPN_NETS_REGEX="${VPN_NETS_REGEX:-^10\\.6\\.}"
+if ip -4 -o addr show 2>/dev/null | awk -v re="$VPN_NETS_REGEX" '$3=="inet" && $4 ~ re {found=1} END{exit !found}' \
+   || (command -v ipsec >/dev/null 2>&1 && ipsec statusall 2>/dev/null | grep -q "ESTABLISHED"); then
+  echo "<span foreground='#fab387'>[VPN]</span>"
 else
-  echo "<span foreground='#bf616a'>[ФАНТОМ]: KAPUTT</span>"
+  echo ""
 fi
 


### PR DESCRIPTION
Scripts hardcoded the network interface to wlp4s0, so they didn’t work on other interfaces. 
VPN widgets call external endpoints via curl and sometimes invoke ipsec every ~5s, which could slow the bar, leak public IP, and fail on systems without ipsec. Waybar’s ASUS click path was hardcoded to /home/pewds.

Changes: 
VPN checks are now local, IPsec is used only as fallback
Net scripts auto‑detect the active IPv4 network interface 
Waybar ASUS now uses $HOME

aanyway, Pewdiepie open sourcerer🪄 is real