### PR TITLE
Enhance network monitoring scripts with dynamic interface detection

### DIFF
--- a/dotfiles/eww/scripts/net/net_download.sh
+++ b/dotfiles/eww/scripts/net/net_download.sh
@@ -9,16 +9,80 @@
 #
 # ─────────────────────────────────────────────────────────────────────────────
 
-iface="wlp4s0"   # Wi-Fi interface
+# Configuration
 max_speed=12500000   # adjust: this is 100 Mbps (100*1e6 / 8)
 
-# First sample
-rx1=$(awk -v iface=$iface '$1 ~ iface {gsub(":", "", $1); print $2}' /proc/net/dev)
-sleep 1
-# Second sample
-rx2=$(awk -v iface=$iface '$1 ~ iface {gsub(":", "", $1); print $2}' /proc/net/dev)
+# Dynamically detect active network interface
+get_active_interface() {
+    # Try to get the interface used for the default route (Linux)
+    if command -v ip >/dev/null 2>&1; then
+        local iface=$(ip route get 1.1.1.1 2>/dev/null | grep -o 'dev [^[:space:]]*' | head -1 | cut -d' ' -f2)
+        
+        # Fallback: get first active non-loopback interface
+        if [ -z "$iface" ]; then
+            iface=$(ip -br link show 2>/dev/null | awk '$2=="UP" && $1!="lo" {print $1; exit}')
+        fi
+    else
+        # macOS fallback using route and netstat
+        local iface=$(route get default 2>/dev/null | grep interface | awk '{print $2}')
+        
+        # Alternative fallback for macOS
+        if [ -z "$iface" ]; then
+            iface=$(netstat -rn | grep '^default' | head -1 | awk '{print $6}')
+        fi
+    fi
+    
+    echo "$iface"
+}
 
-bps=$((rx2 - rx1))              # bytes per second
+iface=$(get_active_interface)
+
+# Validate interface
+if [ -z "$iface" ]; then
+    echo "0"  # No active interface found
+    exit 1
+fi
+
+# Get network statistics (cross-platform)
+get_rx_bytes() {
+    local iface="$1"
+    
+    if [ -f "/proc/net/dev" ]; then
+        # Linux - use /proc/net/dev
+        awk -v iface="$iface" '$1 ~ "^" iface ":" {gsub(":", "", $1); print $2}' /proc/net/dev 2>/dev/null
+    elif command -v netstat >/dev/null 2>&1; then
+        # macOS/BSD - use netstat (bytes received)
+        netstat -ibn | grep "^$iface " | head -1 | awk '{print $7}' 2>/dev/null
+    else
+        echo ""
+    fi
+}
+
+# First sample
+rx1=$(get_rx_bytes "$iface")
+if [ -z "$rx1" ] || ! [[ "$rx1" =~ ^[0-9]+$ ]]; then
+    echo "0"  # Invalid or missing data
+    exit 1
+fi
+
+sleep 1
+
+# Second sample
+rx2=$(get_rx_bytes "$iface")
+if [ -z "$rx2" ] || ! [[ "$rx2" =~ ^[0-9]+$ ]]; then
+    echo "0"  # Invalid or missing data
+    exit 1
+fi
+
+# Calculate bytes per second
+bps=$((rx2 - rx1))
+
+# Handle negative values (counter reset)
+if [ "$bps" -lt 0 ]; then
+    bps=0
+fi
+
+# Calculate percentage
 percent=$((bps * 100 / max_speed))
 
 # Clamp between 0–100

--- a/dotfiles/eww/scripts/net/net_upload.sh
+++ b/dotfiles/eww/scripts/net/net_upload.sh
@@ -5,17 +5,81 @@
 #  as a percentage (0–100) of a configured max speed.
 # ─────────────────────────────────────────────────────────────────────────────
 
-iface="wlp4s0"        # your active Wi-Fi interface (from `ip -br link`)
+# Configuration
 max_speed=12500000    # 100 Mbps = 100e6 / 8 (bytes/sec). Adjust if faster.
 
-# First sample
-tx1=$(awk -v iface=$iface '$1 ~ iface {gsub(":", "", $1); print $10}' /proc/net/dev)
-sleep 1
-# Second sample
-tx2=$(awk -v iface=$iface '$1 ~ iface {gsub(":", "", $1); print $10}' /proc/net/dev)
+# Dynamically detect active network interface
+get_active_interface() {
+    # Try to get the interface used for the default route (Linux)
+    if command -v ip >/dev/null 2>&1; then
+        local iface=$(ip route get 1.1.1.1 2>/dev/null | grep -o 'dev [^[:space:]]*' | head -1 | cut -d' ' -f2)
+        
+        # Fallback: get first active non-loopback interface
+        if [ -z "$iface" ]; then
+            iface=$(ip -br link show 2>/dev/null | awk '$2=="UP" && $1!="lo" {print $1; exit}')
+        fi
+    else
+        # macOS fallback using route and netstat
+        local iface=$(route get default 2>/dev/null | grep interface | awk '{print $2}')
+        
+        # Alternative fallback for macOS
+        if [ -z "$iface" ]; then
+            iface=$(netstat -rn | grep '^default' | head -1 | awk '{print $6}')
+        fi
+    fi
+    
+    echo "$iface"
+}
 
-bps=$((tx2 - tx1))                 # bytes per second
-percent=$((bps * 1000 / max_speed))  # scaled ×10 for sensitivity
+iface=$(get_active_interface)
+
+# Validate interface
+if [ -z "$iface" ]; then
+    echo "0"  # No active interface found
+    exit 1
+fi
+
+# Get network statistics (cross-platform)
+get_tx_bytes() {
+    local iface="$1"
+    
+    if [ -f "/proc/net/dev" ]; then
+        # Linux - use /proc/net/dev (column 10 is TX bytes)
+        awk -v iface="$iface" '$1 ~ "^" iface ":" {gsub(":", "", $1); print $10}' /proc/net/dev 2>/dev/null
+    elif command -v netstat >/dev/null 2>&1; then
+        # macOS/BSD - use netstat (bytes sent)
+        netstat -ibn | grep "^$iface " | head -1 | awk '{print $10}' 2>/dev/null
+    else
+        echo ""
+    fi
+}
+
+# First sample
+tx1=$(get_tx_bytes "$iface")
+if [ -z "$tx1" ] || ! [[ "$tx1" =~ ^[0-9]+$ ]]; then
+    echo "0"  # Invalid or missing data
+    exit 1
+fi
+
+sleep 1
+
+# Second sample
+tx2=$(get_tx_bytes "$iface")
+if [ -z "$tx2" ] || ! [[ "$tx2" =~ ^[0-9]+$ ]]; then
+    echo "0"  # Invalid or missing data
+    exit 1
+fi
+
+# Calculate bytes per second
+bps=$((tx2 - tx1))
+
+# Handle negative values (counter reset)
+if [ "$bps" -lt 0 ]; then
+    bps=0
+fi
+
+# Calculate percentage (scaled ×10 for sensitivity)
+percent=$((bps * 1000 / max_speed))
 
 # Clamp between 0–100
 if [ "$percent" -gt 100 ]; then percent=100; fi


### PR DESCRIPTION
- Replace hardcoded 'wlp4s0' interface with automatic detection
- Add cross-platform compatibility for Linux and macOS systems
- Implement robust error handling and data validation
- Add fallback mechanisms for interface detection using multiple methods
- Handle counter resets and invalid data gracefully
- Improve code structure with dedicated functions for network stats
- Support both /proc/net/dev (Linux) and netstat (macOS/BSD) backends

The scripts now automatically detect the active network interface used for the default route, making them portable across different systems and network configurations without manual interface configuration.