### PR TITLE
fix: typo in bar_spacing shader comments

### DIFF
--- a/dotfiles/cava/shaders/bar_spectrum.frag
+++ b/dotfiles/cava/shaders/bar_spectrum.frag
@@ -8,7 +8,7 @@ uniform float bars[512];
 
 uniform int bars_count;    // number of bars (left + right) (configurable)
 uniform int bar_width;    // bar width (configurable), not used here
-uniform int bar_spacing;    // space bewteen bars (configurable)
+uniform int bar_spacing;    // space between bars (configurable)
 
 uniform vec3 u_resolution; // window resolution
 

--- a/dotfiles/cava/shaders/spectrogram.frag
+++ b/dotfiles/cava/shaders/spectrogram.frag
@@ -9,7 +9,7 @@ uniform float bars[512];
 
 uniform int bars_count;  // number of bars (left + right) (configurable)
 uniform int bar_width;   // bar width (configurable), not used here
-uniform int bar_spacing; // space bewteen bars (configurable)
+uniform int bar_spacing; // space between bars (configurable)
 
 uniform vec3 u_resolution; // window resolution
 

--- a/dotfiles/cava/shaders/winamp_line_style_spectrum.frag
+++ b/dotfiles/cava/shaders/winamp_line_style_spectrum.frag
@@ -36,7 +36,7 @@ uniform float bars[512];
 
 uniform int bars_count;    // number of bars (left + right) (configurable)
 uniform int bar_width;    // bar width (configurable), not used here
-uniform int bar_spacing;    // space bewteen bars (configurable)
+uniform int bar_spacing;    // space between bars (configurable)
 
 uniform vec3 u_resolution; // window resolution
 


### PR DESCRIPTION
Corrected 'bewteen' to 'between' in comments describing the bar_spacing uniform in three shader files for clarity.