### PR TITLE
chore: Removed unused refresh-eww.sh

### DIFF
--- a/dotfiles/hypr/scripts/refresh-eww.sh
+++ b/dotfiles/hypr/scripts/refresh-eww.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-while true; do
-  eww update line_refresh=$(date +%s%3N)
-  sleep 0.05
-done


### PR DESCRIPTION
- There are no instances where `refresh-eww.sh` is called in current code base.
- The eww variable `line_refresh` does not exist in current code base.