### PR TITLE
fixed stylistic issues with the volume widget

### DIFF
--- a/dotfiles/waybar/scripts/volume.sh
+++ b/dotfiles/waybar/scripts/volume.sh
@@ -28,8 +28,12 @@ fi
 # ASCII bar
 filled=$((vol_int / 10))
 empty=$((10 - filled))
-bar=$(printf '█%.0s' $(seq 1 $filled))
-pad=$(printf '░%.0s' $(seq 1 $empty))
+
+bar=""
+pad=""
+((filled > 0)) && bar=$(printf '█%.0s' $(seq 1 $filled))
+((empty > 0)) && pad=$(printf '░%.0s' $(seq 1 $empty))
+
 ascii_bar="[$bar$pad]"
 
 # Color logic
@@ -48,6 +52,7 @@ else
   tooltip="Audio: $vol_int%\nOutput: $sink"
 fi
 
+vol_formatted=$(printf "%3d" "$vol_int")
 # Final JSON output
-echo "{\"text\":\"<span foreground='$fg'>$icon $ascii_bar $vol_int%</span>\",\"tooltip\":\"$tooltip\"}"
+echo "{\"text\":\"<span foreground='$fg'>$icon $ascii_bar $vol_formatted%</span>\",\"tooltip\":\"$tooltip\"}"
 


### PR DESCRIPTION
Hey felix!

There's two issues with the current volume widget in waybar: 

1. Volumes 0% and 100% still show one filled/empty block, which is because of how `seq` works with invalid loop arguments. 
2. When going from 100% to 95%, and from 10% to 5%, the widget's width reduces because the number of digits in the volume number changes. 

This PR fixes both issues. 