### PR TITLE
style: ensure audio_visualizer.py adheres to PEP8

### DIFF
--- a/dotfiles/eww/scripts/audio/audio_visualizer.py
+++ b/dotfiles/eww/scripts/audio/audio_visualizer.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-# ─────────────────────────────────────────────────────────────────────────────
-#  °˖* ૮(  • ᴗ ｡)っ🍸  pewdiepie/archdaemon/dionysh shhheersh
-#  vers. 1.0
-# ─────────────────────────────────────────────────────────────────────────────
-#  Reads /tmp/cava.raw and writes an ASCII‑art file that can be shown by eww, 
-#  waybar, or any terminal widget. Can run as exec once in hyprland config.
-# ─────────────────────────────────────────────────────────────────────────────
+# noinspection SpellCheckingInspection
+"""°˖* ૮(  • ᴗ ｡)っ🍸  pewdiepie/archdaemon/dionysh shhheersh
+vers. 1.0
+
+Reads /tmp/cava.raw and writes an ASCII‑art file that can be shown by eww,
+waybar, or any terminal widget. Can run as exec once in hyprland config.
+"""
+
 
 import argparse
 import os
@@ -15,16 +16,18 @@ import time
 
 import numpy as np
 
+
 # ── Default visual parameters ───────────────────────────────────────────────
-DEFAULT_WIDTH  = 64
+DEFAULT_WIDTH = 64
 DEFAULT_HEIGHT = 12
-DEFAULT_FPS    = 30
-DEFAULT_DECAY  = 0.92               # lower → longer trails
-CHARS = [" ", ".", ":", "·", "•", "•"]   # ascending intensity
+DEFAULT_FPS = 30
+DEFAULT_DECAY = 0.92  # lower → longer trails
+CHARS = [" ", ".", ":", "·", "•", "•"]  # ascending intensity
 
 
 def parse_frame(line: str, width: int) -> list[int]:
     """Turn a semicolon‑separated line from CAVA into a list of ints."""
+
     try:
         return [int(x) for x in line.strip().split(";") if x][:width]
     except ValueError:
@@ -33,19 +36,21 @@ def parse_frame(line: str, width: int) -> list[int]:
 
 def normalize(vals: list[int]) -> np.ndarray:
     """Scale values to the range [0, 1]."""
+
     arr = np.array(vals, dtype=float)
     return (arr - arr.min()) / (arr.max() - arr.min() + 1e-5)
 
 
 def get_char_index(val: float) -> int:
     """Map a normalized value to the appropriate character index."""
+
     return min(int(val * (len(CHARS) - 1)), len(CHARS) - 1)
 
 
 def build_frame(_, history: np.ndarray, height: int, width: int) -> list[str]:
     """Create the ASCII rows from the decay buffer."""
-    frame = [[" " for _ in range(width)] for _ in range(height)]
 
+    frame = [[" " for _ in range(width)] for _ in range(height)]
     for x in range(width):
         for y in range(height):
             strength = history[y, x]
@@ -65,13 +70,13 @@ def run(
     decay: float = DEFAULT_DECAY,
 ) -> None:
     """Main loop – read CAVA output, update the decay buffer, write ASCII."""
+
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
-
     decay_buffer = np.zeros((height, width), dtype=float)
-
     while True:
         try:
             with open(cava_path, "r") as f:
+
                 # read one line at a time from the FIFO
                 line = f.readline()
                 if not line:
@@ -98,18 +103,20 @@ def run(
         ascii_lines = build_frame(values, decay_buffer, height, width)
         with open(out_path, "w") as out:
             out.write("\n".join(ascii_lines))
-
         time.sleep(1.0 / fps)
 
 
-
+# noinspection PyUnusedLocal
 def _handle_sigint(signum, frame):
     """Graceful exit on Ctrl‑C."""
+
     print("\n[+] CAVA ASCII visualizer stopped.")
     sys.exit(0)
 
 
 def main() -> None:
+    """Main function for CAVA → ASCII visualizer."""
+
     parser = argparse.ArgumentParser(
         description="CAVA → ASCII visualizer (compatible with eww/widgets)",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -126,10 +133,8 @@ def main() -> None:
                         help="Refresh rate (frames per second)")
     parser.add_argument("--decay",  type=float, default=DEFAULT_DECAY,
                         help="Trail‑fade factor (0‑1, lower = slower fade)")
-
     args = parser.parse_args()
     signal.signal(signal.SIGINT, _handle_sigint)
-
     print("[+] Starting CAVA ASCII visualizer …")
     run(
         cava_path=args.cava_path,


### PR DESCRIPTION
Ensures that audio_visualizer.py follows the PEP8 style guide (standard style guide for Python).
*No functional differences were made.*
Here are screenshots of pycodestyle (PEP8 style checker) run before and after the changes:

Before:
<img width="539" height="134" alt="before" src="https://github.com/user-attachments/assets/2a06e1e6-a7e1-434f-9833-0fab66309d4d" />

After:
<img width="390" height="55" alt="after" src="https://github.com/user-attachments/assets/eb35faaf-c984-4a00-bdac-32bbd49fae6e" />