### PR TITLE
[Suggestion] remove eww in favor of fabric

### DIFF
--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -62,4 +62,3 @@ running on my **ROG Zephyrus G15** (_dionysus_).
 - [waybar](waybar/) → status bar  
 - [zsh](zsh/) → shell configs  
 
-


### PR DESCRIPTION
Btw you should drop eww in favor of something like fabric.

Fabric is a widgets framework written and configured in Python. Fabric’s main goals are to provide you a simple, easy and high-level way to declare and manage desktop widgets.

>NOTE fabric is  like a 20x boost in performance and better DX  (+ no more eww daemon)

https://wiki.ffpy.org/

Heres a showcase of a rice
https://www.reddit.com/r/unixporn/comments/1hw6ur3