### PR TITLE
Improved Russian translation

### DIFF
--- a/dotfiles/eww/scripts/net/net_vpn_status.sh
+++ b/dotfiles/eww/scripts/net/net_vpn_status.sh
@@ -4,9 +4,8 @@
 
 if sudo /usr/bin/ipsec statusall 2>/dev/null | grep -q "ESTABLISHED"; then
   country=$(curl -s ifconfig.co/country 2>/dev/null)
-  [[ -z "$country" ]] && country="UNKNOWN"
-  echo "[ФАНТОМ]"
+  [[ -z "$country" ]] && country="НЕУСТАНОВЛЕНО"
+  echo "[УЗЕЛ] $country"
 else
-  echo "KAPUTT"
+  echo "[НЕТ СВЯЗИ]"
 fi
-

--- a/dotfiles/eww/windows/misc/welcome_text.yuck
+++ b/dotfiles/eww/windows/misc/welcome_text.yuck
@@ -17,10 +17,9 @@
     (label :text "> Добро пожаловать, ${USER}" :class "label-primary" :halign "end" :style "margin-top: -20px;")
 
     ;; Date Line
-    (label :text "Сегодня: ${welcome_date}" :class "label-primary" :halign "end" :style "margin-top: -10px;")
+    (label :text "Текущая дата: ${welcome_date}" :class "label-primary" :halign "end" :style "margin-top: -10px;")
 
     ;; Weather Line
     (label :text "Погода: ${weather_forecast}" :class "label-primary" :halign "end" :style "margin-top: -10px;")
   )
 )
-

--- a/dotfiles/eww/windows/sys/power_mode_text.yuck
+++ b/dotfiles/eww/windows/sys/power_mode_text.yuck
@@ -11,18 +11,18 @@
   :focusable false
 
   (box :orientation "vertical" :halign "start" :space "4px"
- 
+
         ;; Power Draw
-        (box :orientation "horizontal" :halign "end" :space "4px" :style "margin-top:-10px;"
+        (box :orientation "horizontal" :halign "end" :space "4px" :style "margin-top: -10px;"
           (label :text "> " :class "power-label2"   :halign "end"   )
-          (label :text "энергии:   " :class "power-label")
+          (label :text "нагрузка:   " :class "power-label")
           (label :text power_draw :class "power-value"  :halign "end"  )
         )
 
         ;; CPU Voltage
         (box :orientation "horizontal" :halign "start" :space "4px" :style "margin-top: -10px;"
           (label :text "> " :class "power-label2"   :halign "end"   )
-          (label :text "сос:       " :class "power-label")
+          (label :text "цпу:       " :class "power-label")
           (label :text cpu_voltage :class "power-value"   :halign "end"  )
         )
 
@@ -30,17 +30,14 @@
         (box :orientation "horizontal" :halign "start" :space "4px" :style "margin-top: -10px;"
           (label :text "> " :class "power-label2"   :halign "end"   )
           (label :text "гпу:       " :class "power-label")
-          
           (label :text gpu_voltage :class "power-value"        :halign "end" )
         )
-        
+
            ;; GPU Voltage
         (box :orientation "horizontal" :halign "start" :space "4px" :style "margin-top: -10px;"
           (label :text "> " :class "power-label2"   :halign "end"   )
-          (label :text "вход:      " :class "power-label")
-                       (label :text dc_voltage :class "power-value"    :halign "end" )
+          (label :text "питание:      " :class "power-label")
+          (label :text dc_voltage :class "power-value"    :halign "end" )
         )
       )
     )
-  
-

--- a/dotfiles/eww/windows/sys/power_mode_text.yuck
+++ b/dotfiles/eww/windows/sys/power_mode_text.yuck
@@ -15,7 +15,7 @@
         ;; Power Draw
         (box :orientation "horizontal" :halign "end" :space "4px" :style "margin-top: -10px;"
           (label :text "> " :class "power-label2"   :halign "end"   )
-          (label :text "нагрузка:   " :class "power-label")
+          (label :text "нагрузка:  " :class "power-label")
           (label :text power_draw :class "power-value"  :halign "end"  )
         )
 
@@ -36,7 +36,7 @@
            ;; GPU Voltage
         (box :orientation "horizontal" :halign "start" :space "4px" :style "margin-top: -10px;"
           (label :text "> " :class "power-label2"   :halign "end"   )
-          (label :text "питание:      " :class "power-label")
+          (label :text "напряжение: " :class "power-label")
           (label :text dc_voltage :class "power-value"    :halign "end" )
         )
       )

--- a/dotfiles/eww/windows/sys/right_fan_data.yuck
+++ b/dotfiles/eww/windows/sys/right_fan_data.yuck
@@ -18,30 +18,30 @@
         (box :orientation "horizontal" :halign "end" :space "4px" :style "margin-top:-10px;"
           (label :text "> " :class "power-label2"   :halign "end"   )
           (label :text "цпу вент:  " :class "power-label3")
-      (label :text cpu_fan_rpm :class "power-value" :halign "end"  )
+          (label :text cpu_fan_rpm :class "power-value" :halign "end"  )
         )
 
         ;; FAN
         (box :orientation "horizontal" :halign "start" :space "4px" :style "margin-top: -10px;"
           (label :text "> " :class "power-label2"   :halign "end"   )
-          (label :text "живопоток: " :class "power-label3")
-         (label :text gpu_fan_ascii :class "power-value"  :halign "end"  )
+          (label :text "оперконтроль: " :class "power-label3")
+          (label :text gpu_fan_ascii :class "power-value"  :halign "end"  )
         )
         ;; fan
         (box :orientation "horizontal" :halign "end" :space "4px" :style "margin-top:-10px;"
           (label :text "> " :class "power-label2"   :halign "end"   )
           (label :text "гпу вент:  " :class "power-label3")
-      (label :text gpu_fan_rpm :class "power-value" :halign "end"  )
+          (label :text gpu_fan_rpm :class "power-value" :halign "end"  )
         )
 
         ;;fan
         (box :orientation "horizontal" :halign "start" :space "4px" :style "margin-top: -10px;"
           (label :text "> " :class "power-label2"   :halign "end"   )
-          (label :text "живопоток: " :class "power-label3")
-         (label :text gpu_fan_ascii :class "power-value"  :halign "end"  )
+          (label :text "оперконтроль: " :class "power-label3")
+          (label :text gpu_fan_ascii :class "power-value"  :halign "end"  )
         )
 
- 
+
 )
- 
+
 )

--- a/dotfiles/eww/windows/sys/right_fan_data.yuck
+++ b/dotfiles/eww/windows/sys/right_fan_data.yuck
@@ -17,7 +17,7 @@
         ;; FAN
         (box :orientation "horizontal" :halign "end" :space "4px" :style "margin-top:-10px;"
           (label :text "> " :class "power-label2"   :halign "end"   )
-          (label :text "цпу вент:  " :class "power-label3")
+          (label :text "цпу вент:     " :class "power-label3")
           (label :text cpu_fan_rpm :class "power-value" :halign "end"  )
         )
 
@@ -30,7 +30,7 @@
         ;; fan
         (box :orientation "horizontal" :halign "end" :space "4px" :style "margin-top:-10px;"
           (label :text "> " :class "power-label2"   :halign "end"   )
-          (label :text "гпу вент:  " :class "power-label3")
+          (label :text "гпу вент:     " :class "power-label3")
           (label :text gpu_fan_rpm :class "power-value" :halign "end"  )
         )
 

--- a/dotfiles/waybar/scripts/nordvpn-status.sh
+++ b/dotfiles/waybar/scripts/nordvpn-status.sh
@@ -12,9 +12,8 @@
 
 if sudo ipsec statusall 2>/dev/null | grep -q "ESTABLISHED"; then
   country=$(curl -s ifconfig.co/country 2>/dev/null)
-  [[ -z "$country" ]] && country="UNKNOWN"
-  echo "<span foreground='#fab387'>[ФАНТОМ]: $country</span>"
+  [[ -z "$country" ]] && country="НЕУСТАНОВЛЕНО"
+  echo "<span foreground='#fab387'>[УЗЕЛ]: $country</span>"
 else
-  echo "<span foreground='#bf616a'>[ФАНТОМ]: KAPUTT</span>"
+  echo "<span foreground='#bf616a'>[НЕТ СВЯЗИ]/span>"
 fi
-

--- a/dotfiles/waybar/scripts/nordvpn-status.sh
+++ b/dotfiles/waybar/scripts/nordvpn-status.sh
@@ -3,9 +3,9 @@
 # Description: Checks if VPN interface is active via IP range
 # Usage: Called by Waybar `custom/vpn` every 5s
 # Dependencies: ip, curl (optional, for country lookup)
-# Output: Pango markup → [ФАНТОМ]: Country or KAPUTT
-# Example: <span foreground='#fab387'>[ФАНТОМ]: Japan</span>
-#          <span foreground='#bf616a'>[ФАНТОМ]: KAPUTT</span>
+# Output: Pango markup → [УЗЕЛ]: Country or KAPUTT
+# Example: <span foreground='#fab387'>[УЗЕЛ]: Japan</span>
+#          <span foreground='#bf616a'>[НЕТ СВЯЗИ]</span>
 # ───────────────────────────────────────────────────────────
 
 #!/bin/bash


### PR DESCRIPTION
Some of the original translation was a bit rough:
 - Сегодня (today) -> Текущая дата (current date): _A bit more formal and appropriate for a status display_
 - энергии (energy) -> нагрузка (power load): _I think you meant to say `потребление энергии`, but you cut the wrong part, `потребление` here is more descriptive_
 - сос (? suck ?) -> цпу (CPU): _You used correct translation in a different place_
 - живопоток (livestream) -> оперконтроль (operational control): _`живпоток` doesn't really make sense in Russian, and other translations of livestream does not fit aesthetic_
 - вход (entrance) -> напряжение(voltage) : _`вход` doesn't really make sense, you might use `входное напряжение`, but it's way too long_
 - ФАНТОМ (phantom) -> УЗЕЛ (gateway) 