### PR TITLE
Some Changes Worth Checking Out

### DIFF
--- a/dotfiles/hypr/hyprland.conf
+++ b/dotfiles/hypr/hyprland.conf
@@ -1,7 +1,7 @@
 # ──────────────────────────────────────────────────────────────────────────
 #  °˖* ૮(  • ᴗ ｡)っ🍸  pewdiepie/archdaemon/dionysh shhheersh
 #  Hyprland config 
-#  vers. 1.0
+#  vers. 1.1
 # ──────────────────────────────────────────────────────────────────────────
 
 # ── MONITORS ───────────────────────────────────────────────────────────────
@@ -11,6 +11,8 @@ monitor = eDP-1, preferred, auto, 1.25
 $terminal    = alacritty
 $fileManager = thunar
 $menu        = rofi
+$powerMenu   = ~/.config/waybar/scripts/powermenu.sh
+$webBrowser  = firefox
 
 # ── AUTOSTART ──────────────────────────────────────────────────────────────
 
@@ -151,13 +153,15 @@ bind = SUPER, E, exec, hyprctl switchxkblayout "asus-keyboard-2" 1
 
 # Apps
 bind = ALT, T, exec, $terminal
-bind = ALT, B, exec, firefox
-bind = ALT, F, exec, thunar
+bind = ALT, B, exec, $webBrowser
+bind = ALT, F, exec, $fileManager
 bind = ALT, W, killactive,
 bind = ALT, V, togglefloating,
 bind = ALT, {, pseudo,
 bind = ALT, J, togglesplit,
 bind = ALT, SPACE, exec, rofi -show drun
+bind = ALT, L, exec, $powerMenu
+bind = ALT, TAB, workspace, e+1
 
 # Move focus
 bind = ALT, left,  movefocus, l

--- a/dotfiles/rofi/config_powermenu.rasi
+++ b/dotfiles/rofi/config_powermenu.rasi
@@ -1,0 +1,14 @@
+/* ── Rofi Config ──────────────────────────────
+   Location: ~/.config/rofi/config_powermenu.rasi
+   Description: Basic configuration + theme import
+   ─────────────────────────────────────────── */
+
+configuration {
+    modi: "drun,run";                    // Available modes
+    show-icons: true;                    // Show app icons
+    font: "JetBrainsMono Nerd Font 12";  // Global font
+}
+
+/* Import active theme */
+@theme "~/.config/rofi/theme_powermenu.rasi"
+

--- a/dotfiles/rofi/theme_powermenu.rasi
+++ b/dotfiles/rofi/theme_powermenu.rasi
@@ -1,0 +1,105 @@
+/* ── Rofi Theme ──────────────────────────────
+   °˖* ૮(  • ᴗ ｡)っ🍸  pewdiepie/archdaemon/dionysh
+   shhheersh
+   Vers 1.1
+   Description: Custom styling for Rofi launcher 
+   ─────────────────────────────────────────── */
+
+/* Global defaults */
+* {
+  font: "JetBrainsMono Nerd Font 11";
+  blur: true;
+  padding: 10px;
+  background-color: transparent;
+  border-radius: 0px;  // remove default rounding globally
+}
+
+/* ── Window ──────────────────────────────── */
+window {
+  width: 750px;
+  height: 625px;
+  location: center;
+  blur: true;
+  border: 2px;
+  border-radius: 3px;
+  border-color: #61afef;
+  background-color: transparent;  // let Hyprland handle opacity
+  padding: 0px;
+  margin: 30px 50px;
+}
+
+/* ── Layout ──────────────────────────────── */
+mainbox {
+  orientation: horizontal;
+  children: [ "borderbox" ];
+  spacing: 0px;
+  padding: 0px;
+}
+
+borderbox {
+  orientation: horizontal;
+  children: [ "imagebox", "contentbox" ];
+  padding: 0px;
+  spacing: 0px;
+  border-radius: 3px;
+}
+
+contentbox {
+  orientation: vertical;
+  /*Removed "entry" to get rid of input box: children: [ "entry", "listview" ];
+    left code for "entry" for easy reimplementation */
+  children: [ "listview" ];
+  spacing: 0px;
+  padding: 0px;
+  expand: true;
+}
+
+/* ── Imagebox ────────────────────────────── */
+imagebox {
+  background-image: url("~/.config/rofi/image.png");
+  background-repeat: false;
+  size: 300px 625px;
+}
+
+/* ── Elements ────────────────────────────── */
+element {
+  border-radius: 0px;
+}
+
+element-text, element-icon {
+  padding: 6px 8px;
+  spacing: 2px;
+  text-color: #fab387;
+}
+
+element selected {
+  background-color: #191919;
+  text-color: #e5c07b;
+  border-radius: 3px;
+}
+
+/* ── Input & Prompt ──────────────────────── */
+prompt {
+  enabled: false;
+  background-color: transparent;
+  text-color: #61afef;
+  padding: 5px 10px;
+}
+
+entry {
+  padding: 8px;
+  expand: false;
+  font: "JetBrainsMono Nerd Font 12";
+  text-color: #fab387;
+  border-radius: 0px 3px 0px 0px;
+  background-color: #292e36;  // input field
+}
+
+/* ── Listview ────────────────────────────── */
+listview {
+  lines: 1;
+  background-color: rgba(46, 52, 64, 0.8); // solid background inside blur
+  border-radius: 0px 0px 3px 0px;
+  padding: 5px;
+}
+

--- a/dotfiles/waybar/scripts/powermenu.sh
+++ b/dotfiles/waybar/scripts/powermenu.sh
@@ -7,7 +7,7 @@
 #      # Opens a Rofi menu with power options
 # ─────────────────────────────────────────────────────────────────────────────
 
-rofi_command="rofi -dmenu -p Power"
+rofi_command="rofi -config ~/.config/rofi/powermenuconfig.rasi -dmenu -p Power"
 
 options="Shutdown\nReboot\nLogout\nSuspend\nLock"
 


### PR DESCRIPTION
```markdown
1: Added two files inside ~/.config/rofi
- Added a config and theme file for rofi's power menu.
- Purpose is to not use the "entry" input box and try to streamline the menu's look.

2: Edited Waybar powermenu script file
- Changed rofi run command to load theme_powermenu.rasi

3: Changes to hyprland.conf
- Added $powerMenu and a bind using it so that you can call powermenu.sh without interacting with waybar. This can be seen as a similar feature to Super+L on Windows to lock the pc.
- Added bind for Alt+Tab to switch between workspaces like in Windows. This will only switch to workspaces with a program in it and it does loop back around.
- Added Firefox to My Programs section as $webBrowser
- Changed keybinding for Thunar to use its existing $fileManager variable which was unused(?)

I based my hyprland setup on dionysus; however, due to some Waybar settings and not having an ASUS laptop, I had to make several changes for my own setup and therefore I have backported the changes above to dionysus.

In short, I do not know with 100% certainty that my change of removing 'entry' in the rofi powermenu will not cause an unwanted appearance. I left the code for 'entry' intact so it can be easily re-enabled if the look is unwanted.
```
